### PR TITLE
Build standardizing

### DIFF
--- a/apps/config-builder/package.json
+++ b/apps/config-builder/package.json
@@ -1,14 +1,23 @@
 {
+  "author": {
+    "name": "zoe-codez",
+    "url": "https://github.com/zoe-codez/digital-alchemy"
+  },
   "bin": {
     "config-builder": "main.js"
   },
-  "name": "@digital-alchemy/config-builder",
+  "description": "Terminal based app for managing configurations related to Digital Alchemy applications",
+  "displayName": "Digital Alchemy - Config Builder",
+  "homepage": "https://github.com/zoe-codez/digital-alchemy",
   "license": "MIT",
   "main": "main.js",
-  "displayName": "Config Builder",
-  "version": "23.14.3",
-  "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "name": "@digital-alchemy/config-builder",
   "engines": {
-    "node": ">=16.0.0"
-  }
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
+  },
+  "version": "23.14.3"
 }

--- a/apps/hass-cli/project.json
+++ b/apps/hass-cli/project.json
@@ -55,34 +55,6 @@
       },
       "outputs": ["{options.outputFile}"]
     },
-    "publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "parallel": false,
-        "commands": [
-          {
-            "command": "npx figlet-cli -f Pagga Hass CLI",
-            "description": "Announce it"
-          },
-          {
-            "command": "npx nx build hass-cli --configuration=production",
-            "description": "Create production optimized build"
-          },
-          {
-            "command": "npx terser dist/apps/hass-cli/main.js -c -m --keep-classnames --module > dist/apps/hass-cli/minified.js",
-            "description": "Minify it"
-          },
-          {
-            "command": "echo '#!/usr/bin/env node' > dist/apps/hass-cli/main.js; cat dist/apps/hass-cli/minified.js >> dist/apps/hass-cli/main.js",
-            "description": "Replace output (can't be done in previous step)"
-          },
-          {
-            "command": "npx yarn publish --cwd dist/apps/hass-cli --non-interactive",
-            "description": "Publish it"
-          }
-        ]
-      }
-    },
     "scan-config": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/hass-type-generate/package.json
+++ b/apps/hass-type-generate/package.json
@@ -1,17 +1,22 @@
 {
-  "bin": {
-    "hass-type-generate": "main.js"
-  },
-  "license": "MIT",
-  "description": "",
-  "main": "main.js",
-  "name": "@digital-alchemy/hass-type-generate",
-  "version": "23.14.3",
   "author": {
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
+  "bin": {
+    "hass-type-generate": "main.js"
+  },
+  "description": "Type customization & update script for internal libraries",
+  "displayName": "Digital Alchemy - Hass Type Generate",
+  "license": "MIT",
+  "main": "main.js",
+  "name": "@digital-alchemy/hass-type-generate",
   "engines": {
-    "node": ">=16.0.0"
-  }
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
+  },
+  "version": "23.14.3"
 }

--- a/apps/sampler-app/project.json
+++ b/apps/sampler-app/project.json
@@ -39,34 +39,6 @@
       },
       "outputs": ["{options.outputFile}"]
     },
-    "publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "parallel": false,
-        "commands": [
-          {
-            "command": "npx figlet-cli -f Pagga Sampler App",
-            "description": "Announce it"
-          },
-          {
-            "command": "npx nx build sampler-app --configuration=production",
-            "description": "Create production optimized build"
-          },
-          {
-            "command": "npx terser dist/apps/sampler-app/main.js -c -m --keep-classnames --module > dist/apps/sampler-app/minified.js",
-            "description": "Minify it"
-          },
-          {
-            "command": "echo '#!/usr/bin/env node' > dist/apps/sampler-app/main.js; cat dist/apps/sampler-app/minified.js >> dist/apps/sampler-app/main.js",
-            "description": "Replace output (can't be done in previous step)"
-          },
-          {
-            "command": "npx yarn publish --cwd dist/apps/sampler-app --non-interactive",
-            "description": "Publish it"
-          }
-        ]
-      }
-    },
     "scan-config": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/automation-logic/package.json
+++ b/libs/automation-logic/package.json
@@ -1,13 +1,19 @@
 {
   "author": {
-    "name": "zoe-codez"
+    "name": "zoe-codez",
+    "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/automation-logic",
-  "displayName": "Automation Logic",
+  "description": "Canned logic for use with Home Automation",
+  "displayName": "Digital Alchemy - Automation Logic",
+  "homepage": "https://github.com/zoe-codez/digital-alchemy",
   "license": "MIT",
-  "version": "23.14.3",
+  "name": "@digital-alchemy/automation-logic",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
+  },
   "scripts": {
     "postinstall": "hass-type-generate || exit 0"
   },
-  "description": "HELLO WORLD"
+  "version": "23.14.3"
 }

--- a/libs/automation-logic/project.json
+++ b/libs/automation-logic/project.json
@@ -4,6 +4,28 @@
   "sourceRoot": "libs/automation-logic/src",
   "projectType": "library",
   "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
+        "main": "libs/automation-logic/src/index.ts",
+        "outputPath": "dist/libs/automation-logic",
+        "packageJson": "libs/automation-logic/package.json",
+        "tsConfig": "libs/automation-logic/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/automation-logic/*.md",
+          "libs/automation-logic/package.json"
+        ]
+      },
+      "configurations": {
+        "production": {
+          "optimization": true,
+          "fileReplacements": []
+        }
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
@@ -29,29 +51,6 @@
             "description": "Publish it"
           }
         ]
-      }
-    },
-    "build": {
-      "executor": "@nrwl/js:tsc",
-      "outputs": ["{options.outputPath}"],
-      "options": {
-        "outputPath": "dist/libs/automation-logic",
-        "tsConfig": "libs/automation-logic/tsconfig.lib.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
-        "packageJson": "libs/automation-logic/package.json",
-        "main": "libs/automation-logic/src/index.ts",
-        "assets": [
-          "libs/automation-logic/*.md",
-          "libs/automation-logic/package.json"
-        ]
-      },
-      "configurations": {
-        "production": {
-          "optimization": true,
-          "extractLicenses": false,
-          "fileReplacements": []
-        }
       }
     }
   },

--- a/libs/boilerplate/package.json
+++ b/libs/boilerplate/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "@digital-alchemy/boilerplate",
-  "displayName": "Boilerplate",
-  "license": "MIT",
-  "version": "23.14.3",
+  "author": {
+    "name": "zoe-codez",
+    "url": "https://github.com/zoe-codez/digital-alchemy"
+  },
+  "description": "Application bootstrapping, logging, configuration, and more for Digital Alchemy",
+  "displayName": "Digital Alchemy - Boilerplate",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/boilerplate",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
   },
-  "engines": {
-    "node": ">=16.0.0"
-  }
+  "version": "23.14.3"
 }

--- a/libs/boilerplate/project.json
+++ b/libs/boilerplate/project.json
@@ -8,29 +8,21 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/boilerplate",
-        "tsConfig": "libs/boilerplate/tsconfig.lib.json",
-        "packageJson": "libs/boilerplate/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/boilerplate/src/index.ts",
+        "outputPath": "dist/libs/boilerplate",
+        "packageJson": "libs/boilerplate/package.json",
+        "tsConfig": "libs/boilerplate/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
         "assets": [
-          "libs/boilerplate/package.json",
-          "libs/boilerplate/README.md"
+          "libs/boilerplate/*.md",
+          "libs/boilerplate/package.json"
         ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
-          "buildableProjectDepsInPackageJsonType": "peerDependencies",
-          "updateBuildableProjectDepsInPackageJson": true,
-          "fileReplacements": [
-            {
-              "replace": "libs/boilerplate/README.md",
-              "with": "libs/boilerplate/docs/npm.md"
-            }
-          ]
+          "fileReplacements": []
         }
       }
     },

--- a/libs/home-assistant/package.json
+++ b/libs/home-assistant/package.json
@@ -1,13 +1,19 @@
 {
   "author": {
-    "name": "zoe-codez"
+    "name": "zoe-codez",
+    "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/home-assistant",
-  "displayName": "Home Assistant",
+  "description": "Websocket & REST adapters for Home Assistant",
+  "displayName": "Digital Alchemy - Home Assistant",
+  "homepage": "https://github.com/zoe-codez/digital-alchemy",
   "license": "MIT",
-  "version": "23.14.3",
+  "name": "@digital-alchemy/home-assistant",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
+  },
   "scripts": {
     "postinstall": "hass-type-generate || exit 0"
   },
-  "description": "HELLO WORLD"
+  "version": "23.14.3"
 }

--- a/libs/home-assistant/project.json
+++ b/libs/home-assistant/project.json
@@ -4,6 +4,28 @@
   "sourceRoot": "libs/home-assistant/src",
   "projectType": "library",
   "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
+        "main": "libs/home-assistant/src/index.ts",
+        "outputPath": "dist/libs/home-assistant",
+        "packageJson": "libs/home-assistant/package.json",
+        "tsConfig": "libs/home-assistant/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/home-assistant/*.md",
+          "libs/home-assistant/package.json"
+        ]
+      },
+      "configurations": {
+        "production": {
+          "optimization": true,
+          "fileReplacements": []
+        }
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
@@ -37,29 +59,6 @@
       "options": {
         "jestConfig": "libs/home-assistant/jest.config.ts",
         "passWithNoTests": true
-      }
-    },
-    "build": {
-      "executor": "@nrwl/js:tsc",
-      "outputs": ["{options.outputPath}"],
-      "options": {
-        "outputPath": "dist/libs/home-assistant",
-        "tsConfig": "libs/home-assistant/tsconfig.lib.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
-        "packageJson": "libs/home-assistant/package.json",
-        "main": "libs/home-assistant/src/index.ts",
-        "assets": [
-          "libs/home-assistant/*.md",
-          "libs/home-assistant/package.json"
-        ]
-      },
-      "configurations": {
-        "production": {
-          "optimization": true,
-          "extractLicenses": false,
-          "fileReplacements": []
-        }
       }
     }
   },

--- a/libs/mqtt/package.json
+++ b/libs/mqtt/package.json
@@ -3,12 +3,14 @@
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/mqtt",
-  "license": "MIT",
-  "version": "23.14.3",
+  "description": "MQTT bindings for Digital Alchemy",
+  "displayName": "Digital Alchemy - MQTT",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/mqtt",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
-  }
+  },
+  "version": "23.14.3"
 }

--- a/libs/mqtt/project.json
+++ b/libs/mqtt/project.json
@@ -8,18 +8,20 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/mqtt",
-        "tsConfig": "libs/mqtt/tsconfig.lib.json",
-        "packageJson": "libs/mqtt/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/mqtt/src/index.ts",
-        "assets": ["libs/mqtt/*.md", "libs/mqtt/package.json"]
+        "outputPath": "dist/libs/mqtt",
+        "packageJson": "libs/mqtt/package.json",
+        "tsConfig": "libs/mqtt/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/mqtt/*.md",
+          "libs/mqtt/package.json"
+        ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
           "fileReplacements": []
         }
       }

--- a/libs/rgb-matrix/package.json
+++ b/libs/rgb-matrix/package.json
@@ -1,14 +1,16 @@
 {
   "author": {
-    "name": "zoe-codez"
+    "name": "zoe-codez",
+    "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/rgb-matrix",
-  "displayName": "RGB Matrix",
-  "license": "MIT",
-  "version": "23.14.3",
+  "description": "Rendering and layout utilities for rgb matrix",
+  "displayName": "Digital Alchemy - RGB Matrix",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/rgb-matrix",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
-  }
+  },
+  "version": "23.14.3"
 }

--- a/libs/rgb-matrix/project.json
+++ b/libs/rgb-matrix/project.json
@@ -8,12 +8,12 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/rgb-matrix",
-        "tsConfig": "libs/rgb-matrix/tsconfig.lib.json",
-        "packageJson": "libs/rgb-matrix/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/rgb-matrix/src/index.ts",
+        "outputPath": "dist/libs/rgb-matrix",
+        "packageJson": "libs/rgb-matrix/package.json",
+        "tsConfig": "libs/rgb-matrix/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
         "assets": [
           "libs/rgb-matrix/*.md",
           "libs/rgb-matrix/package.json"
@@ -22,7 +22,6 @@
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
           "fileReplacements": []
         }
       }

--- a/libs/server/package.json
+++ b/libs/server/package.json
@@ -3,13 +3,14 @@
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/server",
-  "license": "MIT",
-  "displayName": "Server",
-  "version": "23.14.3",
+  "description": "Module to enable http functionality within Digital Alchemy",
+  "displayName": "Digital Alchemy - Server",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/server",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
-  }
+  },
+  "version": "23.14.3"
 }

--- a/libs/server/project.json
+++ b/libs/server/project.json
@@ -8,20 +8,20 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/server",
-        "tsConfig": "libs/server/tsconfig.lib.json",
-        "packageJson": "libs/server/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/server/src/index.ts",
-        "assets": ["libs/server/package.json"]
+        "outputPath": "dist/libs/server",
+        "packageJson": "libs/server/package.json",
+        "tsConfig": "libs/server/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/server/*.md",
+          "libs/server/package.json"
+        ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
-          "buildableProjectDepsInPackageJsonType": "dependencies",
-          "updateBuildableProjectDepsInPackageJson": true,
           "fileReplacements": []
         }
       }

--- a/libs/testing/package.json
+++ b/libs/testing/package.json
@@ -3,13 +3,14 @@
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/testing",
-  "displayName": "Testing",
-  "license": "MIT",
-  "version": "23.14.3",
+  "description": "Utilities for building unit tests with Digital Alchemy",
+  "displayName": "Digital Alchemy - Testing",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/testing",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
-  }
+  },
+  "version": "23.14.3"
 }

--- a/libs/testing/project.json
+++ b/libs/testing/project.json
@@ -8,20 +8,20 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/testing",
-        "tsConfig": "libs/testing/tsconfig.lib.json",
-        "packageJson": "libs/testing/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/testing/src/index.ts",
-        "assets": ["libs/testing/package.json"]
+        "outputPath": "dist/libs/testing",
+        "packageJson": "libs/testing/package.json",
+        "tsConfig": "libs/testing/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/testing/*.md",
+          "libs/testing/package.json"
+        ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
-          "buildableProjectDepsInPackageJsonType": "dependencies",
-          "updateBuildableProjectDepsInPackageJson": true,
           "fileReplacements": []
         }
       }

--- a/libs/tty/package.json
+++ b/libs/tty/package.json
@@ -3,8 +3,14 @@
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/tty",
+  "description": "Terminal prompts, menus, and general interactions",
+  "displayName": "Digital Alchemy - TTY",
+  "homepage": "https://github.com/zoe-codez/digital-alchemy",
   "license": "MIT",
-  "version": "23.14.3",
-  "displayName": "TTY"
+  "name": "@digital-alchemy/tty",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
+  },
+  "version": "23.14.3"
 }

--- a/libs/tty/project.json
+++ b/libs/tty/project.json
@@ -8,18 +8,20 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/tty",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
-        "tsConfig": "libs/tty/tsconfig.lib.json",
-        "packageJson": "libs/tty/package.json",
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/tty/src/index.ts",
-        "assets": ["libs/tty/*.md", "libs/tty/package.json"]
+        "outputPath": "dist/libs/tty",
+        "packageJson": "libs/tty/package.json",
+        "tsConfig": "libs/tty/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/tty/*.md",
+          "libs/tty/package.json"
+        ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
           "fileReplacements": []
         }
       }

--- a/libs/utilities/package.json
+++ b/libs/utilities/package.json
@@ -3,13 +3,14 @@
     "name": "zoe-codez",
     "url": "https://github.com/zoe-codez/digital-alchemy"
   },
-  "name": "@digital-alchemy/utilities",
-  "displayName": "Utilities",
-  "license": "MIT",
-  "version": "23.14.3",
+  "description": "Basic constants and utilities for use within Digital Alchemy",
+  "displayName": "Digital Alchemy - Utilities",
   "homepage": "https://github.com/zoe-codez/digital-alchemy",
+  "license": "MIT",
+  "name": "@digital-alchemy/utilities",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zoe-codez/digital-alchemy.git"
-  }
+  },
+  "version": "23.14.3"
 }

--- a/libs/utilities/project.json
+++ b/libs/utilities/project.json
@@ -8,20 +8,20 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/utilities",
-        "tsConfig": "libs/utilities/tsconfig.lib.json",
-        "packageJson": "libs/utilities/package.json",
-        "buildableProjectDepsInPackageJsonType": "dependencies",
-        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "peerDependencies",
         "main": "libs/utilities/src/index.ts",
-        "assets": ["libs/utilities/package.json"]
+        "outputPath": "dist/libs/utilities",
+        "packageJson": "libs/utilities/package.json",
+        "tsConfig": "libs/utilities/tsconfig.lib.json",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "assets": [
+          "libs/boilerplate/*.md",
+          "libs/boilerplate/package.json"
+        ]
       },
       "configurations": {
         "production": {
           "optimization": true,
-          "extractLicenses": false,
-          "buildableProjectDepsInPackageJsonType": "dependencies",
-          "updateBuildableProjectDepsInPackageJson": true,
           "fileReplacements": []
         }
       }


### PR DESCRIPTION
Resolves #4 

- package.json files all follow the same template
- library project have build blocks standardized
- libraries use `peerDependencies` instead of `dependencies`